### PR TITLE
State scalatest version to be ignored by dependabot explicitly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,7 @@ updates:
     - 5.12.0
   - dependency-name: org.scalatest:scalatest_2.13
     versions:
-      - x.x.x-SNAP+
-      - x.x.x-M+
+      - 3.2.4-M1
+      - 3.3.0-SNAP1
+      - 3.3.0-SNAP2
+      - 3.3.0-SNAP3


### PR DESCRIPTION
Might resolve #24. We only know, when in master. Please *do not* delete branch until we are sure, that no desired version is being blocked.